### PR TITLE
PHP7 fatal error fix: Redefinition of parameter

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -81,9 +81,9 @@ class telegramBot
    *
    * @return Array
    */
-  public function forwardMessage($chat_id, $from_chat_id, $from_chat_id)
+  public function forwardMessage($chat_id, $from_chat_id, $message_id)
   {
-    $params = compact('chat_id', 'from_chat_id', 'from_chat_id');
+    $params = compact('chat_id', 'from_chat_id', 'message_id');
 
     return $this->sendRequest('forwardMessage', $params);
   }


### PR DESCRIPTION
```
PHP Fatal error:  Redefinition of parameter $from_chat_id
```

judging from the doc, might be a variable name typo?
