### PR TITLE
Update extensions in uploadFile for sendAudio

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -492,6 +492,7 @@ class telegramBot
         'image/bmp'   =>  '.bmp',
         'image/tiff'  =>  '.tif',
         'audio/ogg'   =>  '.ogg',
+        'audio/mpeg'  =>  '.mp3',
         'video/mp4'   =>  '.mp4',
         'image/webp'  =>  '.webp'
       );


### PR DESCRIPTION
I have added the audio/mpeg mimetype for the sendAudio function, because Telegram only accepts .mp3 files up to 50 mb.
